### PR TITLE
fix: correct casing for ASAR integrity validation options

### DIFF
--- a/packages/en-US/docs/guide/source-code-protection.md
+++ b/packages/en-US/docs/guide/source-code-protection.md
@@ -39,9 +39,9 @@ build:
   # ... other configurations
   electronFuses:
     # Enable ASAR integrity validation
-    EnableEmbeddedAsarIntegrityValidation: true
+    enableEmbeddedAsarIntegrityValidation: true
     # (Optional, but recommended) Ensure Electron only loads app code from app.asar
-    OnlyLoadAppFromAsar: true
+    onlyLoadAppFromAsar: true
 ```
 
 ### V8 Bytecode

--- a/packages/zh-CN/docs/guide/source-code-protection.md
+++ b/packages/zh-CN/docs/guide/source-code-protection.md
@@ -39,9 +39,9 @@ build:
   # ... 其他配置
   electronFuses:
     # 启用 ASAR 完整性校验
-    EnableEmbeddedAsarIntegrityValidation: true
+    enableEmbeddedAsarIntegrityValidation: true
     # （可选，但推荐）确保 Electron 仅从 app.asar 加载应用程序代码
-    OnlyLoadAppFromAsar: true
+    onlyLoadAppFromAsar: true
 ```
 
 ### V8 字节码


### PR DESCRIPTION
This pull request updates the documentation in both the English and Chinese guides to use the correct casing for Electron fuse configuration options, ensuring consistency with Electron's expected configuration keys.

**Documentation updates:**

* Updated the `electronFuses` configuration examples in `source-code-protection.md` (both `en-US` and `zh-CN` versions) to use camelCase keys (`enableEmbeddedAsarIntegrityValidation` and `onlyLoadAppFromAsar`) instead of PascalCase. [[1]](diffhunk://#diff-a48decae1db90a1966dd3d1d7cc7abeaeeae13610b62b03cc0bfc9d2d351f668L42-R44) [[2]](diffhunk://#diff-5d4fc152f463d210d3c0b4bec2196a165f2d4a74820717ad6dedda88269c18b4L42-R44)